### PR TITLE
Fix case-sensitive link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 # Networking and data storage with Kotlin Multiplatform Mobile
 
-This repository is the code corresponding to the hands-on lab [Networking and data storage with Kotlin Multiplatform Mobile](https://play.kotlinlang.org/hands-on/Networking%20and%20data%20storage%20with%20Kotlin%20Multiplatform%20Mobile/01_introduction).
+This repository is the code corresponding to the hands-on lab [Networking and data storage with Kotlin Multiplatform Mobile](https://play.kotlinlang.org/hands-on/Networking%20and%20Data%20Storage%20with%20Kotlin%20Multiplatfrom%20Mobile/01_Introduction).


### PR DESCRIPTION
The previous link landed on a blank page. instead of the hands-on.